### PR TITLE
Project name should be unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small spying and stubbing library for Clojure and ClojureScript.
 
 ## Install
 
-Add `[test-doubles "0.1.0"]` to `[:profiles :dev :dependencies]` in your `project.clj`.
+Add `[gpm/test-doubles "0.1.0"]` to `[:profiles :dev :dependencies]` in your `project.clj`.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject test-doubles "0.1.0"
+(defproject gpm/test-doubles "0.1.0"
   :description "A small spying and stubbing library for Clojure and ClojureScript"
   :url "https://github.com/GreenPowerMonitor/test-doubles"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
The project name should be more unique than `test-doubles`, changed to `gpm/test-doubles`.

Sounds fine?