### PR TITLE
Fixing a bug in the arity of ignoring function when using clojure

### DIFF
--- a/src/gpm/test_doubles/core.cljc
+++ b/src/gpm/test_doubles/core.cljc
@@ -47,7 +47,7 @@
 #?(:clj
    (defn- create-ignoring-list [functions]
      (->> functions
-          (mapcat #(conj [] % `(fn [])))
+          (mapcat #(conj [] % `(constantly nil)))
           vec)))
 
 #?(:clj


### PR DESCRIPTION
Ignoring was working find for any function in ClojureScript but only worked for functions with 0-arity in Clojure.