### PR TITLE
Fix footnote as examples have cljs specific code

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ In the following example, we are using two **stubs** (one with `:maps` option an
 
 <a name="nota1"></a> 1. Notice that some verbs that are functions in Clojure might be macros in ClojureScript or viceversa. For instance `+` is a function in Clojure, but a macro in ClojureScript.
 
-<a name="nota2"></a> 2. All the examples in this document should work in both Clojure and ClojureScript. We take advantage of _implicit macro loading_ and _auto-aliasing clojure namespaces_, read more about it in the [Differences from Clojure](https://clojurescript.org/about/differences) section of the ClojureScript site.
+<a name="nota2"></a> 2. All the examples in this document are written in ClojureScript, due to the usage of interop such as `js/Error`. Changing them to run in Clojure will require using the Clojure equivalents.
 
 
 ## License


### PR DESCRIPTION
As we discussed, the examples are not 100% portable.