### PR TITLE
Setting scm in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,10 @@
   :url "https://github.com/GreenPowerMonitor/test-doubles"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+
+  :scm {:name "git"
+        :url "https://github.com/GreenPowerMonitor/test-doubles"}
+
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]]
 


### PR DESCRIPTION
First deploy used my fork's url as the clojars source, this fixes it so that it always points to greenpowermonitor's repo.