### PR TITLE
Preserve return value of with-doubles body

### DIFF
--- a/src/greenpowermonitor/test_doubles.cljc
+++ b/src/greenpowermonitor/test_doubles.cljc
@@ -75,8 +75,9 @@
            {:keys [spying stubbing ignoring throwing]
             :or {spying [] stubbing [] ignoring [] throwing []}} doubles]
        `(with-redefs ~(create-doubles-list spying stubbing ignoring throwing)
-          ~@body
-          (reset! *spies-atom* {})))))
+          (let [result# (do ~@body)]
+            (reset! *spies-atom* {})
+            result#)))))
 
 (defn calls-to [function]
   (if-let [calls (some-> *spies-atom* deref (get function) deref)]

--- a/test/greenpowermonitor/test_doubles_test.cljc
+++ b/test/greenpowermonitor/test_doubles_test.cljc
@@ -132,3 +132,7 @@
                     :cljs (ex-message e))))
           (is (= some-map
                  (ex-data e))))))))
+
+(deftest returning-the-body-value
+  (is (= "hi there"
+         (td/with-doubles "hi there"))))


### PR DESCRIPTION
Hi,

thanks for writing test-doubles. I'm surprised it isn't the number one result when searching for "clojure mock", it beats all the alternatives I've found.

This pull requests adds support for putting `with-doubles` inside the assertion rather than the other way around. Would you be interested in it? There are situations where I find this convenient, especially when using metosin's test-it:

```
(facts "about my function"
  (with-doubles ....) => some-result
  (with-doubles ...) => some-other-result)
```